### PR TITLE
Add image placeholder for Arcane Fractured Jinx

### DIFF
--- a/skins/222/222060/222999/placeholder
+++ b/skins/222/222060/222999/placeholder
@@ -1,1 +1,2 @@
 
+<img src="https://i.ibb.co/B2gHSxNb/arcane-fractured-jinx-powderr.png" alt="Açıklama" width="500">


### PR DESCRIPTION
<img width="1349" height="1214" alt="arcane_fractured_jinx_powderr" src="https://github.com/user-attachments/assets/7747a052-8047-406b-84bb-4f92df00a13c" />
