### PR TITLE
Update README: fix links, reflect name-based structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
   <img src="./icon.ico" alt="Rose Icon" width="128" height="128">
 
-[![Installer](https://img.shields.io/badge/Installer-Windows-32A832)](https://gitlab.com/Alban1911/Rose/-/releases) [![Ko-Fi](https://img.shields.io/badge/KoFi-Donate-C03030?logo=ko-fi&logoColor=white)](https://ko-fi.com/roseapp) [![Discord](https://img.shields.io/discord/1465467335946272780?color=32A832&logo=discord&logoColor=white&label=Discord)](https://discord.com/invite/roseapp)  [![License](https://img.shields.io/badge/License-Open%20Source-C03030)](LICENSE)
+[![Installer](https://img.shields.io/badge/Installer-Windows-32A832)](https://github.com/Alban1911/Rose/releases/latest) [![Ko-Fi](https://img.shields.io/badge/KoFi-Donate-C03030?logo=ko-fi&logoColor=white)](https://ko-fi.com/roseapp) [![Discord](https://img.shields.io/discord/1465467335946272780?color=32A832&logo=discord&logoColor=white&label=Discord)](https://discord.com/invite/roseapp)  [![License](https://img.shields.io/badge/License-Open%20Source-C03030)](LICENSE)
 
 
 </div>
@@ -15,9 +15,11 @@
 
 ## About
 
-This repository contains a comprehensive collection of League of Legends skin assets, organized by champion and skin IDs. All assets are extracted and maintained by the **[Rose](https://gitlab.com/Alban1911/Rose)** community.
+This repository contains a comprehensive collection of League of Legends skin assets, organized by champion and skin **names** for easy browsing. All assets are extracted and maintained by the **[Rose](https://github.com/Alban1911/Rose)** community.
 
-**[Rose](https://gitlab.com/Alban1911/Rose)** is a powerful tool that allows you to unlock and use any skin in League of Legends, including legacy, limited, and exclusive skins that are no longer available through normal means.
+This is the human-friendly version of the skin repository — champions and skins use readable names instead of numeric IDs, and skin files are plain `.zip` archives. The [RoseSkin](https://github.com/Alban1911/RoseSkin) repository is the optimized counterpart used directly by Rose, with numeric IDs and encrypted `.rse` files.
+
+**[Rose](https://github.com/Alban1911/Rose)** is an open-source automatic skin changer for League of Legends that enables seamless access to all skins in the game, including legacy, limited, and exclusive skins that are no longer available through normal means.
 
 ## Features
 
@@ -32,32 +34,33 @@ This repository contains a comprehensive collection of League of Legends skin as
 
 ```
 skins/
-├── {champion_id}/
-│   ├── {skin_id}/
-│   │   ├── {skin_id}.zip          # Skin asset package
-│   │   └── {chroma_id}/            # Chroma variants (if available)
-│   │       └── {chroma_id}.zip     # Chroma asset package
-│   └── {skin_id}/                  # Skins with custom forms
-│       ├── {skin_id}.png           # Base skin preview (only for custom forms)
-│       ├── {skin_id}.zip           # Skin asset package
-│       └── {form_id}/              # Custom form variants
-│           ├── {form_id}.png       # Form preview image
-│           └── {form_id}.zip       # Form asset package
+├── {champion_name}/
+│   ├── {skin_name}/
+│   │   ├── {skin_name}.zip              # Skin asset package
+│   │   └── {skin_name} ({chroma})/      # Chroma variants (if available)
+│   │       └── {skin_name} ({chroma}).zip
+│   └── {skin_name}/                     # Skins with custom forms
+│       ├── {skin_name}.png              # Base skin preview (only for custom forms)
+│       ├── {skin_name}.zip              # Skin asset package
+│       └── {skin_name} (Form N)/        # Custom form variants
+│           ├── {skin_name} (Form N).png # Form preview image
+│           └── {skin_name} (Form N).zip # Form asset package
 ```
 
 ### File Organization
 
-- **Champion IDs**: Numeric identifiers (e.g., 1, 10, 101, etc.)
-- **Skin & Chroma IDs**: Calculated as `champion_id * 1000 + skin_number`
+- **Champions**: Organized by champion name (e.g., Ahri, Lux, Aatrox)
+- **Skins**: Named after the skin (e.g., Academy Ahri, Elementalist Lux)
+- **Chromas**: Subfolder named with the chroma variant in parentheses (e.g., Academy Ahri (Ahri-versary))
 - **File Types**: 
   - `.png` - Preview images (only included for skins with custom forms)
   - `.zip` - Complete skin asset packages
 
 ## Getting Started
 
-1. **Download Rose**: Get the latest installer from our [releases page](https://gitlab.com/Alban1911/Rose/-/releases)
+1. **Download Rose**: Get the latest installer from our [releases page](https://github.com/Alban1911/Rose/releases/latest)
 2. **Install the Tool**: Follow the installation instructions
-3. **Apply Skins**: Use [Rose](https://gitlab.com/Alban1911/Rose) to apply any skin in-game
+3. **Apply Skins**: Use [Rose](https://github.com/Alban1911/Rose) to apply any skin in-game
 
 ### Contributing
 
@@ -69,11 +72,9 @@ LeagueSkins is open source! Contributions are welcome:
 
 ## Legal Disclaimer
 
-**Important**: This project is not endorsed by Riot Games and does not represent the views or opinions of Riot Games or any of its affiliates. Riot Games and all related properties are trademarks or registered trademarks of Riot Games, Inc.
+This project is not endorsed by or affiliated with Riot Games. Riot Games and all related properties are trademarks or registered trademarks of Riot Games, Inc.
 
-The use of custom skin tools may violate Riot Games' Terms of Service. Users proceed at their own risk.
-
-Custom skins are allowed under Riot's terms of service and do not trigger detection as long as you are not discussing or advertising the use of the skins within the game.
+Custom skins are allowed under Riot's terms of service and are not detected. Do not discuss or advertise skin tools in game. Users proceed at their own risk.
 
 ## Support
 
@@ -85,4 +86,4 @@ Your support helps keep the project alive and motivates continued development!
 
 ---
 
-**Powered by [Rose](https://gitlab.com/Alban1911/Rose)**
+**Powered by [Rose](https://github.com/Alban1911/Rose)**


### PR DESCRIPTION
## Summary
- Fix all Rose links from GitLab to GitHub (badges, body text, footer)
- Rewrite repository structure and file organization sections to reflect actual name-based layout (champion names + skin names) instead of numeric IDs
- Add paragraph explaining this is the human-friendly counterpart to RoseSkin
- Fix contradictory legal disclaimer to match Rose's wording

## Test plan
- [x] Verify all links resolve correctly
- [x] Review rendered README on GitHub
- [x] Confirm structure section matches actual repo layout